### PR TITLE
Added RStudio and knitr caching files

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -1,5 +1,13 @@
 # History files
 .Rhistory
 
+# RStudio
+.Rapp.history
+.RData
+
+# knitr cache files
+report_cache
+report_files
+
 # Example code in package build process
 *-Ex.R


### PR DESCRIPTION
Added the command history and environment cache that is used by RStudio.  Also added the default caching directories used by the knitr package.  RStudio is the defacto standard IDE that is used for R development and knitr is an included package in RStudio for creating documents.  These can be broken out into a separate gitignore but very few people use R without using RStudio. 
